### PR TITLE
Add environment variable checks for llm and tts

### DIFF
--- a/backend/llm/index.js
+++ b/backend/llm/index.js
@@ -2,6 +2,12 @@ const axios = require('axios');
 require('dotenv').config();
 
 const TOGETHER_API_KEY = process.env.TOGETHER_API_KEY;
+
+if (!TOGETHER_API_KEY) {
+  const msg = 'Missing TOGETHER_API_KEY. Please set it in your environment variables.';
+  console.error(msg);
+  throw new Error(msg);
+}
 const TOGETHER_MODEL   = 'meta-llama/Llama-3-8b-chat-hf';
 
 // — Personality prompt

--- a/backend/tts/index.js
+++ b/backend/tts/index.js
@@ -4,6 +4,18 @@ require('dotenv').config();
 const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
 const VOICE_ID = process.env.ELEVENLABS_VOICE_ID;
 
+if (!ELEVENLABS_API_KEY) {
+  const msg = 'Missing ELEVENLABS_API_KEY. Please set it in your environment variables.';
+  console.error(msg);
+  throw new Error(msg);
+}
+
+if (!VOICE_ID) {
+  const msg = 'Missing ELEVENLABS_VOICE_ID. Please set it in your environment variables.';
+  console.error(msg);
+  throw new Error(msg);
+}
+
 async function speak(text) {
   const url = `https://api.elevenlabs.io/v1/text-to-speech/${VOICE_ID}/stream`;
 


### PR DESCRIPTION
## Summary
- verify required API keys when loading `backend/llm` and `backend/tts`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cfcc5a94083238b9d6401e74f4d45