### PR TITLE
Add stop function for wake word listener

### DIFF
--- a/backend/wakeword/index.js
+++ b/backend/wakeword/index.js
@@ -46,4 +46,21 @@ async function initWakeWord(callback) {
   }
 }
 
-module.exports = { initWakeWord };
+async function stopWakeWord() {
+  try {
+    if (recorder) {
+      await recorder.stop();
+      recorder.release();
+      recorder = null;
+    }
+    if (porcupine) {
+      porcupine.release();
+      porcupine = null;
+    }
+    console.log('[WAKE] Wake word listener stopped');
+  } catch (err) {
+    console.error('[ERROR] Failed to stop wake word:', err);
+  }
+}
+
+module.exports = { initWakeWord, stopWakeWord };


### PR DESCRIPTION
## Summary
- enable stopping of the wake word listener

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cfd3491cc8323880574cbb26e61fa